### PR TITLE
Allow retries if password is incorrect

### DIFF
--- a/src/dbus.rs
+++ b/src/dbus.rs
@@ -66,6 +66,7 @@ impl AuthenticationAgent {
             .send(AuthenticationEvent::Started {
                 cookie: cookie.to_string(),
                 message: message.to_string(),
+                retry_message: None,
                 names,
             })
             .map_err(|_| PolkitError::Failed("Failed to send data.".to_string()))?;
@@ -113,6 +114,8 @@ impl AuthenticationAgent {
                         stdin.write_all(cookie.as_bytes()).await?;
                         stdin.write_all(b"\n").await?;
 
+                        let mut last_info: Option<String> = None;
+
                         let reader = BufReader::new(stdout);
                         let mut lines = reader.lines();
                         while let Some(line) = lines.next_line().await? {
@@ -124,13 +127,29 @@ impl AuthenticationAgent {
                                     stdin.write_all(pw.as_bytes()).await?;
                                     stdin.write_all(b"\n").await?;
                                 }
+                            } else if let Some(info) = line.strip_prefix("PAM_TEXT_INFO") {
+                                let msg = info.trim().to_string();
+                                tracing::debug!("helper replied with info: {}", msg);
+
+                                if msg.contains("minute") && msg.contains("unlock") {
+                                    last_info = Some(msg.clone());
+                                    self.sender
+                                        .send(AuthenticationEvent::AuthorizationRetry {
+                                            cookie: cookie.to_string(),
+                                            retry_message: Some(msg),
+                                        })
+                                        .unwrap();
+                                }
                             } else if line.starts_with("FAILURE") {
                                 tracing::debug!("helper replied with failure.");
+
+                                let retry_msg = last_info.clone().unwrap_or_else(|| {
+                                    "Authentication failed. Please try again.".to_string()
+                                });
                                 self.sender
                                     .send(AuthenticationEvent::AuthorizationRetry {
                                         cookie: cookie.to_string(),
-                                        retry_message: "Authentication failed. Please try again."
-                                            .to_string(),
+                                        retry_message: Some(retry_msg),
                                     })
                                     .unwrap();
                                 continue;

--- a/src/events.rs
+++ b/src/events.rs
@@ -6,6 +6,7 @@ pub enum AuthenticationEvent {
     Started {
         cookie: String,
         message: String,
+        retry_message: Option<String>,
         names: Vec<String>,
     },
     /// Polkit sent a request for the authentication to be canceled.
@@ -26,7 +27,7 @@ pub enum AuthenticationEvent {
     /// The user provided a password, but it was incorrect.
     AuthorizationRetry {
         cookie: String,
-        retry_message: String,
+        retry_message: Option<String>,
     },
 }
 
@@ -39,11 +40,13 @@ impl Debug for AuthenticationEvent {
             AuthenticationEvent::Started {
                 cookie,
                 message,
+                retry_message,
                 names,
             } => f
                 .debug_struct("Started")
                 .field("cookie", &cookie)
                 .field("message", &message)
+                .field("retry_message", &retry_message)
                 .field("names", &names)
                 .finish(),
             AuthenticationEvent::Canceled { cookie } => {

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -219,6 +219,7 @@ impl AsyncComponent for App {
                 AuthenticationEvent::Started {
                     cookie,
                     message,
+                    retry_message,
                     names,
                 } => {
                     if self.cookie.is_none() {
@@ -226,7 +227,7 @@ impl AsyncComponent for App {
                         self.message = message;
                         self.identities = names;
                         self.authenticating = false;
-                        self.retry_message = None;
+                        self.retry_message = retry_message;
                     }
                 }
                 AuthenticationEvent::Canceled { cookie }
@@ -259,7 +260,7 @@ impl AsyncComponent for App {
                 } => {
                     if let Some(c) = &self.cookie {
                         if *c == cookie {
-                            self.retry_message = Some(retry_message);
+                            self.retry_message = retry_message;
                             self.authenticating = false;
                         }
                     }


### PR DESCRIPTION
fixes #16 

# Changes
- removed the alert window
- added 2 new events Succeeded and Retry
- some margin changes

# Screenshots
Initial Prompt:
<img width="454" height="253" alt="image" src="https://github.com/user-attachments/assets/8729cf6c-a8c8-4bcc-82c4-041260c956b1" />

When authenticating:
<img width="452" height="279" alt="image" src="https://github.com/user-attachments/assets/b1244fa1-6810-405a-b407-6b25152ceabf" />

After Incorrect Password:
<img width="455" height="281" alt="image" src="https://github.com/user-attachments/assets/9aedc295-798b-41e8-933f-cbafcd09feb7" />

