### PR TITLE
fix: zeroize event and use pair of mpsc channels

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1195,6 +1195,7 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "zbus",
+ "zeroize",
 ]
 
 [[package]]
@@ -1760,6 +1761,26 @@ dependencies = [
  "static_assertions",
  "winnow",
  "zvariant",
+]
+
+[[package]]
+name = "zeroize"
+version = "1.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
+dependencies = [
+ "zeroize_derive",
+]
+
+[[package]]
+name = "zeroize_derive"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,3 +25,4 @@ tracing-subscriber = { version = "0.3.18", features = [
   "ansi",
 ] }
 zbus = { version = "5.7.1", default-features = false, features = ["tokio"] }
+zeroize = { version = "1.8.2", features = ["zeroize_derive"] }


### PR DESCRIPTION
Currently the password persists on the heap and can be trivially obtained by coredumping the soteria process, even long after the authentication took place.

The conflated event enum is now split into agent/user ones to be used in a pair of mpsc channels instead of a single broadcast, so it is removed from the buffer once received. The event enums (including the password field) are also zeroized when dropped.

Coredump thus no longer contains the password.